### PR TITLE
Remove #undefine/#define __FUNC__

### DIFF
--- a/src/matrix/lis_matrix.c
+++ b/src/matrix/lis_matrix.c
@@ -66,8 +66,6 @@
  * lis_matrix_set_option
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_init"
 LIS_INT lis_matrix_init(LIS_MATRIX *Amat)
 {
 
@@ -88,8 +86,6 @@ LIS_INT lis_matrix_init(LIS_MATRIX *Amat)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_check"
 LIS_INT lis_matrix_check(LIS_MATRIX A, LIS_INT level)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -188,9 +184,6 @@ LIS_INT lis_matrix_check(LIS_MATRIX A, LIS_INT level)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_create"
 LIS_INT lis_matrix_create(LIS_Comm comm, LIS_MATRIX *Amat)
 {
 	LIS_INT nprocs,my_rank;
@@ -225,8 +218,6 @@ LIS_INT lis_matrix_create(LIS_Comm comm, LIS_MATRIX *Amat)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_size"
 LIS_INT lis_matrix_set_size(LIS_MATRIX Amat, LIS_INT local_n, LIS_INT global_n)
 {
 	LIS_INT nprocs,my_rank;
@@ -283,8 +274,6 @@ LIS_INT lis_matrix_set_size(LIS_MATRIX Amat, LIS_INT local_n, LIS_INT global_n)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_LU_create"
 LIS_INT lis_matrix_LU_create(LIS_MATRIX A)
 {
 	LIS_MATRIX_CORE		L,U;
@@ -315,8 +304,6 @@ LIS_INT lis_matrix_LU_create(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_LU_destroy"
 LIS_INT lis_matrix_LU_destroy(LIS_MATRIX_CORE Amat)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -338,8 +325,6 @@ LIS_INT lis_matrix_LU_destroy(LIS_MATRIX_CORE Amat)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_DLU_destroy"
 LIS_INT lis_matrix_DLU_destroy(LIS_MATRIX Amat)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -358,8 +343,6 @@ LIS_INT lis_matrix_DLU_destroy(LIS_MATRIX Amat)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_storage_destroy"
 LIS_INT lis_matrix_storage_destroy(LIS_MATRIX Amat)
 {
 
@@ -415,8 +398,6 @@ LIS_INT lis_matrix_storage_destroy(LIS_MATRIX Amat)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_destroy"
 LIS_INT lis_matrix_destroy(LIS_MATRIX Amat)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -436,8 +417,6 @@ LIS_INT lis_matrix_destroy(LIS_MATRIX Amat)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_duplicate"
 LIS_INT lis_matrix_duplicate(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 	LIS_INT err;
@@ -520,8 +499,6 @@ LIS_INT lis_matrix_duplicate(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 #endif
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_struct"
 LIS_INT lis_matrix_copy_struct(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -532,8 +509,6 @@ LIS_INT lis_matrix_copy_struct(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_range"
 LIS_INT lis_matrix_get_range(LIS_MATRIX A, LIS_INT *is, LIS_INT *ie)
 {
 	LIS_INT err;
@@ -550,8 +525,6 @@ LIS_INT lis_matrix_get_range(LIS_MATRIX A, LIS_INT *is, LIS_INT *ie)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_size"
 LIS_INT lis_matrix_get_size(LIS_MATRIX A, LIS_INT *local_n, LIS_INT *global_n)
 {
 	LIS_INT err;
@@ -568,8 +541,6 @@ LIS_INT lis_matrix_get_size(LIS_MATRIX A, LIS_INT *local_n, LIS_INT *global_n)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_nnz"
 LIS_INT lis_matrix_get_nnz(LIS_MATRIX A, LIS_INT *nnz)
 {
 	LIS_INT err;
@@ -585,8 +556,6 @@ LIS_INT lis_matrix_get_nnz(LIS_MATRIX A, LIS_INT *nnz)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_assemble"
 LIS_INT lis_matrix_assemble(LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -670,16 +639,12 @@ LIS_INT lis_matrix_assemble(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_is_assembled"
 LIS_INT lis_matrix_is_assembled(LIS_MATRIX A)
 {
   if( A->status!=LIS_MATRIX_NULL ) return !LIS_SUCCESS;
   else                             return  LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_value"
 LIS_INT lis_matrix_set_value(LIS_INT flag, LIS_INT i, LIS_INT j, LIS_SCALAR value, LIS_MATRIX A)
 {
 	LIS_INT n,gn,is,k;
@@ -783,8 +748,6 @@ LIS_INT lis_matrix_set_value(LIS_INT flag, LIS_INT i, LIS_INT j, LIS_SCALAR valu
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_values"
 LIS_INT lis_matrix_set_values(LIS_INT flag, LIS_INT n, LIS_SCALAR value[], LIS_MATRIX A)
 {
   LIS_INT i,j;
@@ -802,8 +765,6 @@ LIS_INT lis_matrix_set_values(LIS_INT flag, LIS_INT n, LIS_SCALAR value[], LIS_M
   return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_type"
 LIS_INT lis_matrix_set_type(LIS_MATRIX A, LIS_INT matrix_type)
 {
 	LIS_INT err;
@@ -824,8 +785,6 @@ LIS_INT lis_matrix_set_type(LIS_MATRIX A, LIS_INT matrix_type)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_type"
 LIS_INT lis_matrix_get_type(LIS_MATRIX A, LIS_INT *matrix_type)
 {
 	LIS_INT err;
@@ -841,8 +800,6 @@ LIS_INT lis_matrix_get_type(LIS_MATRIX A, LIS_INT *matrix_type)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_destroyflag"
 LIS_INT lis_matrix_set_destroyflag(LIS_MATRIX A, LIS_INT flag)
 {
 	LIS_INT err;
@@ -865,8 +822,6 @@ LIS_INT lis_matrix_set_destroyflag(LIS_MATRIX A, LIS_INT flag)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_destroyflag"
 LIS_INT lis_matrix_get_destroyflag(LIS_MATRIX A, LIS_INT *flag)
 {
 	LIS_INT err;
@@ -882,8 +837,6 @@ LIS_INT lis_matrix_get_destroyflag(LIS_MATRIX A, LIS_INT *flag)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc"
 LIS_INT lis_matrix_malloc(LIS_MATRIX A, LIS_INT nnz_row, LIS_INT nnz[])
 {
 	LIS_INT n,k;
@@ -918,8 +871,6 @@ LIS_INT lis_matrix_malloc(LIS_MATRIX A, LIS_INT nnz_row, LIS_INT nnz[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_unset"
 LIS_INT lis_matrix_unset(LIS_MATRIX A)
 {
 	LIS_INT err;

--- a/src/matrix/lis_matrix_bsc.c
+++ b/src/matrix/lis_matrix_bsc.c
@@ -61,8 +61,6 @@
  * lis_matrix_transpose
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_bsc"
 LIS_INT lis_matrix_set_bsc(LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT *bptr, LIS_INT *bindex, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -106,8 +104,6 @@ LIS_INT lis_matrix_set_bsc(LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT *bptr
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_bsc"
 LIS_INT lis_matrix_setDLU_bsc(LIS_INT bnr, LIS_INT bnc, LIS_INT lbnnz, LIS_INT ubnnz, LIS_MATRIX_DIAG D, LIS_INT *lbptr, LIS_INT *lbindex, LIS_SCALAR *lvalue, LIS_INT *ubptr, LIS_INT *ubindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -171,8 +167,6 @@ LIS_INT lis_matrix_setDLU_bsc(LIS_INT bnr, LIS_INT bnc, LIS_INT lbnnz, LIS_INT u
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_bsc"
 LIS_INT lis_matrix_malloc_bsc(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT **bptr, LIS_INT **bindex, LIS_SCALAR **value)
 {
 	LIS_INT	nc;
@@ -209,8 +203,6 @@ LIS_INT lis_matrix_malloc_bsc(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz,
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_bsc"
 LIS_INT lis_matrix_elements_copy_bsc(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_ptr, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT	i,j,k;
@@ -251,8 +243,6 @@ LIS_INT lis_matrix_elements_copy_bsc(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_IN
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_bsc"
 LIS_INT lis_matrix_copy_bsc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT	err;
@@ -344,8 +334,6 @@ LIS_INT lis_matrix_copy_bsc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2bsc"
 LIS_INT lis_matrix_convert_csc2bsc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT	i,j,k,n,bnr,bnc;
@@ -555,8 +543,6 @@ LIS_INT lis_matrix_convert_csc2bsc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_bsc2csr"
 LIS_INT lis_matrix_convert_bsc2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,l;
@@ -734,8 +720,6 @@ LIS_INT lis_matrix_convert_bsc2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_bsc"
 LIS_INT lis_matrix_get_diagonal_bsc(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k,bi,bj,bjj,nr;
@@ -792,8 +776,6 @@ LIS_INT lis_matrix_get_diagonal_bsc(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_bsc"
 LIS_INT lis_matrix_shift_diagonal_bsc(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j,k,bi,bj,bjj,nr;
@@ -850,8 +832,6 @@ LIS_INT lis_matrix_shift_diagonal_bsc(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_bsc"
 LIS_INT lis_matrix_scale_bsc(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -925,8 +905,6 @@ LIS_INT lis_matrix_scale_bsc(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_bsc"
 LIS_INT lis_matrix_scale_symm_bsc(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -1003,8 +981,6 @@ LIS_INT lis_matrix_scale_symm_bsc(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_bsc"
 LIS_INT lis_matrix_normf_bsc(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT j;
@@ -1065,8 +1041,6 @@ LIS_INT lis_matrix_normf_bsc(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_bsc"
 LIS_INT lis_matrix_split_bsc(LIS_MATRIX A)
 {
         LIS_INT i,j,np;
@@ -1272,8 +1246,6 @@ LIS_INT lis_matrix_split_bsc(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_bsc"
 LIS_INT lis_matrix_merge_bsc(LIS_MATRIX A)
 {
 	LIS_INT i,j,np,nr,nc;
@@ -1333,8 +1305,6 @@ LIS_INT lis_matrix_merge_bsc(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_bsc"
 LIS_INT lis_matrix_solve_bsc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,k,ii,jj,nr,bnr,bnc,bs;
@@ -1708,8 +1678,6 @@ LIS_INT lis_matrix_solve_bsc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_bsc"
 LIS_INT lis_matrix_solvet_bsc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,k,ii,jj,nr,bnr,bnc,bs;

--- a/src/matrix/lis_matrix_bsr.c
+++ b/src/matrix/lis_matrix_bsr.c
@@ -61,8 +61,6 @@
  * lis_matrix_transpose
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_bsr"
 LIS_INT lis_matrix_set_bsr(LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT *bptr, LIS_INT *bindex, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -105,8 +103,6 @@ LIS_INT lis_matrix_set_bsr(LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT *bptr
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_bsr"
 LIS_INT lis_matrix_setDLU_bsr(LIS_INT bnr, LIS_INT bnc, LIS_INT lbnnz, LIS_INT ubnnz, LIS_MATRIX_DIAG D, LIS_INT *lbptr, LIS_INT *lbindex, LIS_SCALAR *lvalue, LIS_INT *ubptr, LIS_INT *ubindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -170,8 +166,6 @@ LIS_INT lis_matrix_setDLU_bsr(LIS_INT bnr, LIS_INT bnc, LIS_INT lbnnz, LIS_INT u
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_bsr"
 LIS_INT lis_matrix_malloc_bsr(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT **bptr, LIS_INT **bindex, LIS_SCALAR **value)
 {
 	LIS_INT	nr;
@@ -208,8 +202,6 @@ LIS_INT lis_matrix_malloc_bsr(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz,
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_bsr"
 LIS_INT lis_matrix_elements_copy_bsr(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_INT bnnz, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_ptr, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT	i,j,k;
@@ -250,8 +242,6 @@ LIS_INT lis_matrix_elements_copy_bsr(LIS_INT n, LIS_INT bnr, LIS_INT bnc, LIS_IN
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_bsr"
 LIS_INT lis_matrix_copy_bsr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -343,8 +333,6 @@ LIS_INT lis_matrix_copy_bsr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2bsr"
 LIS_INT lis_matrix_convert_csr2bsr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,n,bnr,bnc;
@@ -548,8 +536,6 @@ LIS_INT lis_matrix_convert_csr2bsr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_bsr2csr"
 LIS_INT lis_matrix_convert_bsr2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k;
@@ -682,8 +668,6 @@ LIS_INT lis_matrix_convert_bsr2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_bsr"
 LIS_INT lis_matrix_get_diagonal_bsr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k,bi,bj,bjj,nr;
@@ -740,8 +724,6 @@ LIS_INT lis_matrix_get_diagonal_bsr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_bsr"
 LIS_INT lis_matrix_shift_diagonal_bsr(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j,k,bi,bj,bjj,nr;
@@ -798,8 +780,6 @@ LIS_INT lis_matrix_shift_diagonal_bsr(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_bsr"
 LIS_INT lis_matrix_scale_bsr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -873,8 +853,6 @@ LIS_INT lis_matrix_scale_bsr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_bsr"
 LIS_INT lis_matrix_scale_symm_bsr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -951,8 +929,6 @@ LIS_INT lis_matrix_scale_symm_bsr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_bscale_bsr"
 LIS_INT lis_matrix_bscale_bsr(LIS_MATRIX A, LIS_MATRIX_DIAG D)
 {
 	LIS_INT bi,bj;
@@ -1061,8 +1037,6 @@ LIS_INT lis_matrix_bscale_bsr(LIS_MATRIX A, LIS_MATRIX_DIAG D)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_bsr"
 LIS_INT lis_matrix_normf_bsr(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT j;
@@ -1122,8 +1096,6 @@ LIS_INT lis_matrix_normf_bsr(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_bsr"
 LIS_INT lis_matrix_split_bsr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n;
@@ -1329,8 +1301,6 @@ LIS_INT lis_matrix_split_bsr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_bsr"
 LIS_INT lis_matrix_merge_bsr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n,nr;
@@ -1389,8 +1359,6 @@ LIS_INT lis_matrix_merge_bsr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_bsr"
 LIS_INT lis_matrix_solve_bsr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,k,ii,jj,nr,bnr,bnc,bs;
@@ -1764,8 +1732,6 @@ LIS_INT lis_matrix_solve_bsr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_bsr"
 LIS_INT lis_matrix_solvet_bsr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,k,ii,jj,nr,bnr,bnc,bs;
@@ -2085,8 +2051,6 @@ LIS_INT lis_matrix_solvet_bsr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_bsr"
 LIS_INT lis_matrix_sort_bsr(LIS_MATRIX A)
 {
 	LIS_INT i,nr,bnr,bs;

--- a/src/matrix/lis_matrix_coo.c
+++ b/src/matrix/lis_matrix_coo.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_coo"
 LIS_INT lis_matrix_set_coo(LIS_INT nnz, LIS_INT *row, LIS_INT *col, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -103,8 +101,6 @@ LIS_INT lis_matrix_set_coo(LIS_INT nnz, LIS_INT *row, LIS_INT *col, LIS_SCALAR *
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_coo"
 LIS_INT lis_matrix_setDLU_coo(LIS_INT lnnz, LIS_INT unnz, LIS_SCALAR *diag, LIS_INT *lrow, LIS_INT *lcol, LIS_SCALAR *lvalue, LIS_INT *urow, LIS_INT *ucol, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -162,8 +158,6 @@ LIS_INT lis_matrix_setDLU_coo(LIS_INT lnnz, LIS_INT unnz, LIS_SCALAR *diag, LIS_
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_coo"
 LIS_INT lis_matrix_malloc_coo(LIS_INT nnz, LIS_INT **row, LIS_INT **col, LIS_SCALAR **value)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -197,9 +191,6 @@ LIS_INT lis_matrix_malloc_coo(LIS_INT nnz, LIS_INT **row, LIS_INT **col, LIS_SCA
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_coo"
 LIS_INT lis_matrix_elements_copy_coo(LIS_INT nnz, LIS_INT *row, LIS_INT *col, LIS_SCALAR *value, LIS_INT *o_row, LIS_INT *o_col, LIS_SCALAR *o_value)
 {
 	LIS_INT	i;
@@ -221,8 +212,6 @@ LIS_INT lis_matrix_elements_copy_coo(LIS_INT nnz, LIS_INT *row, LIS_INT *col, LI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_coo"
 LIS_INT lis_matrix_copy_coo(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -314,8 +303,6 @@ LIS_INT lis_matrix_copy_coo(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_coo"
 LIS_INT lis_matrix_get_diagonal_coo(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i;
@@ -349,8 +336,6 @@ LIS_INT lis_matrix_get_diagonal_coo(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_coo"
 LIS_INT lis_matrix_shift_diagonal_coo(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i;
@@ -384,8 +369,6 @@ LIS_INT lis_matrix_shift_diagonal_coo(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_coo"
 LIS_INT lis_matrix_scale_coo(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -421,8 +404,6 @@ LIS_INT lis_matrix_scale_coo(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_coo"
 LIS_INT lis_matrix_scale_symm_coo(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k;
@@ -461,8 +442,6 @@ LIS_INT lis_matrix_scale_symm_coo(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_coo"
 LIS_INT lis_matrix_normf_coo(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -510,8 +489,6 @@ LIS_INT lis_matrix_normf_coo(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_coo"
 LIS_INT lis_matrix_transpose_coo(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 
@@ -525,8 +502,6 @@ LIS_INT lis_matrix_transpose_coo(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_coo"
 LIS_INT lis_matrix_split_coo(LIS_MATRIX A)
 {
 	LIS_INT i,nnz;
@@ -622,9 +597,6 @@ LIS_INT lis_matrix_split_coo(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_coo"
 LIS_INT lis_matrix_merge_coo(LIS_MATRIX A)
 {
 	LIS_INT i;
@@ -681,8 +653,6 @@ LIS_INT lis_matrix_merge_coo(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_coo"
 LIS_INT lis_matrix_sort_coo(LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -720,9 +690,6 @@ LIS_INT lis_matrix_sort_coo(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2coo"
 LIS_INT lis_matrix_convert_csr2coo(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k;
@@ -776,8 +743,6 @@ LIS_INT lis_matrix_convert_csr2coo(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_coo2csr"
 LIS_INT lis_matrix_convert_coo2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j;

--- a/src/matrix/lis_matrix_csc.c
+++ b/src/matrix/lis_matrix_csc.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_csc"
 LIS_INT lis_matrix_set_csc(LIS_INT nnz, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -90,8 +88,6 @@ LIS_INT lis_matrix_set_csc(LIS_INT nnz, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_csc"
 LIS_INT lis_matrix_setDLU_csc(LIS_INT nnzl, LIS_INT nnzu, LIS_SCALAR *diag, LIS_INT *lptr, LIS_INT *lindex, LIS_SCALAR *lvalue, LIS_INT *uptr, LIS_INT *uindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -107,8 +103,6 @@ LIS_INT lis_matrix_setDLU_csc(LIS_INT nnzl, LIS_INT nnzu, LIS_SCALAR *diag, LIS_
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_csc"
 LIS_INT lis_matrix_malloc_csc(LIS_INT n, LIS_INT nnz, LIS_INT **ptr, LIS_INT **index, LIS_SCALAR **value)
 {
 	LIS_INT err;
@@ -121,9 +115,6 @@ LIS_INT lis_matrix_malloc_csc(LIS_INT n, LIS_INT nnz, LIS_INT **ptr, LIS_INT **i
 	return err;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_csc"
 LIS_INT lis_matrix_elements_copy_csc(LIS_INT np, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_ptr, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT	i,j;
@@ -158,8 +149,6 @@ LIS_INT lis_matrix_elements_copy_csc(LIS_INT np, LIS_INT *ptr, LIS_INT *index, L
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_csc"
 LIS_INT lis_matrix_copy_csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -251,8 +240,6 @@ LIS_INT lis_matrix_copy_csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_csc"
 LIS_INT lis_matrix_get_diagonal_csc(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -294,8 +281,6 @@ LIS_INT lis_matrix_get_diagonal_csc(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_csc"
 LIS_INT lis_matrix_shift_diagonal_csc(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j;
@@ -336,8 +321,6 @@ LIS_INT lis_matrix_shift_diagonal_csc(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_csc"
 LIS_INT lis_matrix_scale_csc(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -381,8 +364,6 @@ LIS_INT lis_matrix_scale_csc(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_csc"
 LIS_INT lis_matrix_scale_symm_csc(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -426,8 +407,6 @@ LIS_INT lis_matrix_scale_symm_csc(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_csc"
 LIS_INT lis_matrix_normf_csc(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -474,8 +453,6 @@ LIS_INT lis_matrix_normf_csc(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_csc"
 LIS_INT lis_matrix_transpose_csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -488,8 +465,6 @@ LIS_INT lis_matrix_transpose_csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return err;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_csc"
 LIS_INT lis_matrix_split_csc(LIS_MATRIX A)
 {
 	LIS_INT i,j,np;
@@ -676,9 +651,6 @@ LIS_INT lis_matrix_split_csc(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_csc"
 LIS_INT lis_matrix_merge_csc(LIS_MATRIX A)
 {
 	LIS_INT i,j,n,np;
@@ -734,8 +706,6 @@ LIS_INT lis_matrix_merge_csc(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_csc"
 LIS_INT lis_matrix_sort_csc(LIS_MATRIX A)
 {
 	LIS_INT i,np;
@@ -773,8 +743,6 @@ LIS_INT lis_matrix_sort_csc(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_csc"
 LIS_INT lis_matrix_solve_csc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n,np;
@@ -835,8 +803,6 @@ LIS_INT lis_matrix_solve_csc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_csc"
 LIS_INT lis_matrix_solvet_csc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,np;
@@ -899,8 +865,6 @@ LIS_INT lis_matrix_solvet_csc(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2csc"
 LIS_INT lis_matrix_convert_csr2csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,jj,k,l;
@@ -1086,8 +1050,6 @@ LIS_INT lis_matrix_convert_csr2csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csc2csr"
 LIS_INT lis_matrix_convert_csc2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,jj,k,l;

--- a/src/matrix/lis_matrix_csr.c
+++ b/src/matrix/lis_matrix_csr.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_csr"
 LIS_INT lis_matrix_set_csr(LIS_INT nnz, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -103,8 +101,6 @@ LIS_INT lis_matrix_set_csr(LIS_INT nnz, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_csr"
 LIS_INT lis_matrix_setDLU_csr(LIS_INT nnzl, LIS_INT nnzu, LIS_SCALAR *diag, LIS_INT *lptr, LIS_INT *lindex, LIS_SCALAR *lvalue, LIS_INT *uptr, LIS_INT *uindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -162,8 +158,6 @@ LIS_INT lis_matrix_setDLU_csr(LIS_INT nnzl, LIS_INT nnzu, LIS_SCALAR *diag, LIS_
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_csr"
 LIS_INT lis_matrix_malloc_csr(LIS_INT n, LIS_INT nnz, LIS_INT **ptr, LIS_INT **index, LIS_SCALAR **value)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -197,9 +191,6 @@ LIS_INT lis_matrix_malloc_csr(LIS_INT n, LIS_INT nnz, LIS_INT **ptr, LIS_INT **i
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_csr"
 LIS_INT lis_matrix_elements_copy_csr(LIS_INT n, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_ptr, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT	i,j;
@@ -234,8 +225,6 @@ LIS_INT lis_matrix_elements_copy_csr(LIS_INT n, LIS_INT *ptr, LIS_INT *index, LI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_csr"
 LIS_INT lis_matrix_copy_csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -335,8 +324,6 @@ LIS_INT lis_matrix_copy_csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copyDLU_csr"
 LIS_INT lis_matrix_copyDLU_csr(LIS_MATRIX Ain, LIS_MATRIX_DIAG *D, LIS_MATRIX *L, LIS_MATRIX *U)
 {
 	LIS_INT err;
@@ -444,8 +431,6 @@ LIS_INT lis_matrix_copyDLU_csr(LIS_MATRIX Ain, LIS_MATRIX_DIAG *D, LIS_MATRIX *L
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_csr"
 LIS_INT lis_matrix_get_diagonal_csr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -486,8 +471,6 @@ LIS_INT lis_matrix_get_diagonal_csr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_csr"
 LIS_INT lis_matrix_shift_diagonal_csr(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j;
@@ -527,8 +510,6 @@ LIS_INT lis_matrix_shift_diagonal_csr(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_csr"
 LIS_INT lis_matrix_scale_csr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -572,8 +553,6 @@ LIS_INT lis_matrix_scale_csr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_csr"
 LIS_INT lis_matrix_scale_symm_csr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -617,8 +596,6 @@ LIS_INT lis_matrix_scale_symm_csr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_csr"
 LIS_INT lis_matrix_normf_csr(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -665,8 +642,6 @@ LIS_INT lis_matrix_normf_csr(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_csr"
 LIS_INT lis_matrix_transpose_csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -685,8 +660,6 @@ LIS_INT lis_matrix_transpose_csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_csr"
 LIS_INT lis_matrix_split_csr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n;
@@ -873,9 +846,6 @@ LIS_INT lis_matrix_split_csr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_csr"
 LIS_INT lis_matrix_merge_csr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n;
@@ -931,8 +901,6 @@ LIS_INT lis_matrix_merge_csr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split2_csr"
 LIS_INT lis_matrix_split2_csr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n;
@@ -1102,8 +1070,6 @@ LIS_INT lis_matrix_split2_csr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_csr"
 LIS_INT lis_matrix_sort_csr(LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -1141,8 +1107,6 @@ LIS_INT lis_matrix_sort_csr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_csr"
 LIS_INT lis_matrix_solve_csr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n,jj;
@@ -1364,8 +1328,6 @@ LIS_INT lis_matrix_solve_csr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_csr"
 LIS_INT lis_matrix_solvet_csr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,jj,n;

--- a/src/matrix/lis_matrix_dia.c
+++ b/src/matrix/lis_matrix_dia.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_dia"
 LIS_INT lis_matrix_set_dia(LIS_INT nnd, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -102,8 +100,6 @@ LIS_INT lis_matrix_set_dia(LIS_INT nnd, LIS_INT *index, LIS_SCALAR *value, LIS_M
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_dia"
 LIS_INT lis_matrix_setDLU_dia(LIS_INT lnnd, LIS_INT unnd, LIS_SCALAR *diag, LIS_INT *lindex, LIS_SCALAR *lvalue, LIS_INT *uindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -159,8 +155,6 @@ LIS_INT lis_matrix_setDLU_dia(LIS_INT lnnd, LIS_INT unnd, LIS_SCALAR *diag, LIS_
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_dia"
 LIS_INT lis_matrix_malloc_dia(LIS_INT n, LIS_INT nnd, LIS_INT **index, LIS_SCALAR **value)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -186,9 +180,6 @@ LIS_INT lis_matrix_malloc_dia(LIS_INT n, LIS_INT nnd, LIS_INT **index, LIS_SCALA
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_dia"
 LIS_INT lis_matrix_elements_copy_dia(LIS_INT n, LIS_INT nnd, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT is,ie;
@@ -221,8 +212,6 @@ LIS_INT lis_matrix_elements_copy_dia(LIS_INT n, LIS_INT nnd, LIS_INT *index, LIS
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_dia"
 LIS_INT lis_matrix_copy_dia(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -310,8 +299,6 @@ LIS_INT lis_matrix_copy_dia(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_dia"
 LIS_INT lis_matrix_get_diagonal_dia(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -363,8 +350,6 @@ LIS_INT lis_matrix_get_diagonal_dia(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_dia"
 LIS_INT lis_matrix_shift_diagonal_dia(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j,k;
@@ -422,8 +407,6 @@ LIS_INT lis_matrix_shift_diagonal_dia(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_dia"
 LIS_INT lis_matrix_scale_dia(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,js,je,jj;
@@ -566,8 +549,6 @@ LIS_INT lis_matrix_scale_dia(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_dia"
 LIS_INT lis_matrix_scale_symm_dia(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,js,je,jj;
@@ -710,8 +691,6 @@ LIS_INT lis_matrix_scale_symm_dia(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_dia"
 LIS_INT lis_matrix_normf_dia(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -759,8 +738,6 @@ LIS_INT lis_matrix_normf_dia(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_dia"
 LIS_INT lis_matrix_transpose_dia(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 
@@ -774,8 +751,6 @@ LIS_INT lis_matrix_transpose_dia(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_dia"
 LIS_INT lis_matrix_split_dia(LIS_MATRIX A)
 {
 	LIS_INT i,j,n,nnd;
@@ -921,9 +896,6 @@ LIS_INT lis_matrix_split_dia(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_dia"
 LIS_INT lis_matrix_merge_dia(LIS_MATRIX A)
 {
         LIS_INT i,j,k,n,is;
@@ -1019,8 +991,6 @@ LIS_INT lis_matrix_merge_dia(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_dia"
 LIS_INT lis_matrix_sort_dia(LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -1058,8 +1028,6 @@ LIS_INT lis_matrix_sort_dia(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_dia"
 LIS_INT lis_matrix_solve_dia(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n;
@@ -1122,8 +1090,6 @@ LIS_INT lis_matrix_solve_dia(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_dia"
 LIS_INT lis_matrix_solvet_dia(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n;
@@ -1183,8 +1149,6 @@ LIS_INT lis_matrix_solvet_dia(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2dia"
 LIS_INT lis_matrix_convert_csr2dia(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,jj,k;
@@ -1300,8 +1264,6 @@ LIS_INT lis_matrix_convert_csr2dia(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_dia2csr"
 LIS_INT lis_matrix_convert_dia2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,jj,k,l;

--- a/src/matrix/lis_matrix_diag.c
+++ b/src/matrix/lis_matrix_diag.c
@@ -47,9 +47,6 @@
 #endif
 #include "lislib.h"
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_init"
 LIS_INT lis_matrix_diag_init(LIS_MATRIX_DIAG *D)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -61,8 +58,6 @@ LIS_INT lis_matrix_diag_init(LIS_MATRIX_DIAG *D)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_check"
 LIS_INT lis_matrix_diag_check(LIS_MATRIX_DIAG D, LIS_INT level)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -88,8 +83,6 @@ LIS_INT lis_matrix_diag_check(LIS_MATRIX_DIAG D, LIS_INT level)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_create"
 LIS_INT lis_matrix_diag_create(LIS_INT local_n, LIS_INT global_n, LIS_Comm comm, LIS_MATRIX_DIAG *D)
 {
 	LIS_INT nprocs,my_rank;
@@ -205,8 +198,6 @@ LIS_INT lis_matrix_diag_create(LIS_INT local_n, LIS_INT global_n, LIS_Comm comm,
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_destroy"
 LIS_INT lis_matrix_diag_destroy(LIS_MATRIX_DIAG D)
 {
 	LIS_INT i;
@@ -233,8 +224,6 @@ LIS_INT lis_matrix_diag_destroy(LIS_MATRIX_DIAG D)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_duplicate"
 LIS_INT lis_matrix_diag_duplicate(LIS_MATRIX_DIAG Din, LIS_MATRIX_DIAG *Dout)
 {
 	LIS_INT err,nr,bnmax,t;
@@ -333,8 +322,6 @@ LIS_INT lis_matrix_diag_duplicate(LIS_MATRIX_DIAG Din, LIS_MATRIX_DIAG *Dout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_duplicate"
 LIS_INT lis_matrix_diag_duplicateM(LIS_MATRIX Ain, LIS_MATRIX_DIAG *Dout)
 {
 	LIS_INT nr,err;
@@ -447,8 +434,6 @@ LIS_INT lis_matrix_diag_duplicateM(LIS_MATRIX Ain, LIS_MATRIX_DIAG *Dout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_malloc"
 LIS_INT lis_matrix_diag_mallocM(LIS_MATRIX A, LIS_SCALAR **diag)
 {
 	LIS_INT err;
@@ -486,8 +471,6 @@ LIS_INT lis_matrix_diag_mallocM(LIS_MATRIX A, LIS_SCALAR **diag)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_get_range"
 LIS_INT lis_matrix_diag_get_range(LIS_MATRIX_DIAG D, LIS_INT *is, LIS_INT *ie)
 {
 	LIS_INT err;
@@ -504,8 +487,6 @@ LIS_INT lis_matrix_diag_get_range(LIS_MATRIX_DIAG D, LIS_INT *is, LIS_INT *ie)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_get_size"
 LIS_INT lis_matrix_diag_get_size(LIS_MATRIX_DIAG D, LIS_INT *local_n, LIS_INT *global_n)
 {
 	LIS_INT err;
@@ -522,9 +503,6 @@ LIS_INT lis_matrix_diag_get_size(LIS_MATRIX_DIAG D, LIS_INT *local_n, LIS_INT *g
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_set_blocksize"
 LIS_INT lis_matrix_diag_set_blocksize(LIS_MATRIX_DIAG D, LIS_INT bn, LIS_INT *bns)
 {
 	LIS_INT i,n,nr,bnmax,t;
@@ -588,8 +566,6 @@ LIS_INT lis_matrix_diag_set_blocksize(LIS_MATRIX_DIAG D, LIS_INT bn, LIS_INT *bn
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_copy"
 LIS_INT lis_matrix_diag_copy(LIS_MATRIX_DIAG X, LIS_MATRIX_DIAG Y)
 {
 	LIS_INT i,n,nr,bn;
@@ -632,8 +608,6 @@ LIS_INT lis_matrix_diag_copy(LIS_MATRIX_DIAG X, LIS_MATRIX_DIAG Y)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_scale"
 LIS_INT lis_matrix_diag_scale(LIS_SCALAR alpha, LIS_MATRIX_DIAG D)
 {
 	LIS_INT i,j,nr,bn;
@@ -745,8 +719,6 @@ LIS_INT lis_matrix_diag_scale(LIS_SCALAR alpha, LIS_MATRIX_DIAG D)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_inverse"
 LIS_INT lis_matrix_diag_inverse(LIS_MATRIX_DIAG D)
 {
 	LIS_INT i,k,nr,bn,bs,n;
@@ -805,8 +777,6 @@ LIS_INT lis_matrix_diag_inverse(LIS_MATRIX_DIAG D)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_matvec"
 LIS_INT lis_matrix_diag_matvec(LIS_MATRIX_DIAG D, LIS_VECTOR X, LIS_VECTOR Y)
 {
 	LIS_INT i,nr,bn,bs;
@@ -894,8 +864,6 @@ LIS_INT lis_matrix_diag_matvec(LIS_MATRIX_DIAG D, LIS_VECTOR X, LIS_VECTOR Y)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_matvect"
 LIS_INT lis_matrix_diag_matvect(LIS_MATRIX_DIAG D, LIS_VECTOR X, LIS_VECTOR Y)
 {
 	LIS_INT i,nr,bn,bs;
@@ -977,8 +945,6 @@ LIS_INT lis_matrix_diag_matvect(LIS_MATRIX_DIAG D, LIS_VECTOR X, LIS_VECTOR Y)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_diag_print"
 LIS_INT lis_matrix_diag_print(LIS_MATRIX_DIAG D)
 {
 	LIS_INT	k,i,j,nr,bn,nn;

--- a/src/matrix/lis_matrix_dns.c
+++ b/src/matrix/lis_matrix_dns.c
@@ -76,8 +76,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_dns"
 LIS_INT lis_matrix_set_dns(LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -103,8 +101,6 @@ LIS_INT lis_matrix_set_dns(LIS_SCALAR *value, LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_dns"
 LIS_INT lis_matrix_malloc_dns(LIS_INT n, LIS_INT np, LIS_SCALAR **value)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -121,8 +117,6 @@ LIS_INT lis_matrix_malloc_dns(LIS_INT n, LIS_INT np, LIS_SCALAR **value)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_dns"
 LIS_INT lis_matrix_elements_copy_dns(LIS_INT n, LIS_INT np, LIS_SCALAR *value, LIS_SCALAR *o_value)
 {
 	LIS_INT i,j,is,ie;
@@ -160,8 +154,6 @@ LIS_INT lis_matrix_elements_copy_dns(LIS_INT n, LIS_INT np, LIS_SCALAR *value, L
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_dns"
 LIS_INT lis_matrix_copy_dns(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -219,8 +211,6 @@ LIS_INT lis_matrix_copy_dns(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_dns"
 LIS_INT lis_matrix_get_diagonal_dns(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i;
@@ -240,8 +230,6 @@ LIS_INT lis_matrix_get_diagonal_dns(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_dns"
 LIS_INT lis_matrix_shift_diagonal_dns(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i;
@@ -275,8 +263,6 @@ LIS_INT lis_matrix_shift_diagonal_dns(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_axpy_dns"
 LIS_INT lis_matrix_axpy_dns(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 {
 	LIS_INT i,j,is,ie,n,np;
@@ -333,8 +319,6 @@ LIS_INT lis_matrix_axpy_dns(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_xpay_dns"
 LIS_INT lis_matrix_xpay_dns(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 {
 	LIS_INT i,j,is,ie,n,np;
@@ -391,8 +375,6 @@ LIS_INT lis_matrix_xpay_dns(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_axpyz_dns"
 LIS_INT lis_matrix_axpyz_dns(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B, LIS_MATRIX C)
 {
 	LIS_INT i,j,is,ie,n,np;
@@ -449,8 +431,6 @@ LIS_INT lis_matrix_axpyz_dns(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B, LIS_M
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_dns"
 LIS_INT lis_matrix_scale_dns(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -471,8 +451,6 @@ LIS_INT lis_matrix_scale_dns(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_dns"
 LIS_INT lis_matrix_scale_symm_dns(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -493,8 +471,6 @@ LIS_INT lis_matrix_scale_symm_dns(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_dns"
 LIS_INT lis_matrix_normf_dns(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -542,8 +518,6 @@ LIS_INT lis_matrix_normf_dns(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_dns"
 LIS_INT lis_matrix_transpose_dns(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 
@@ -557,8 +531,6 @@ LIS_INT lis_matrix_transpose_dns(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_dns"
 LIS_INT lis_matrix_split_dns(LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -587,9 +559,6 @@ LIS_INT lis_matrix_split_dns(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_dns"
 LIS_INT lis_matrix_merge_dns(LIS_MATRIX A)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -600,8 +569,6 @@ LIS_INT lis_matrix_merge_dns(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_dns"
 LIS_INT lis_matrix_sort_dns(LIS_MATRIX A)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -612,8 +579,6 @@ LIS_INT lis_matrix_sort_dns(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_dns"
 LIS_INT lis_matrix_solve_dns(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n,np;
@@ -678,8 +643,6 @@ LIS_INT lis_matrix_solve_dns(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_dns"
 LIS_INT lis_matrix_solvet_dns(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n,np;
@@ -740,8 +703,6 @@ LIS_INT lis_matrix_solvet_dns(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2dns"
 LIS_INT lis_matrix_convert_csr2dns(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j;
@@ -814,8 +775,6 @@ LIS_INT lis_matrix_convert_csr2dns(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_dns2csr"
 LIS_INT lis_matrix_convert_dns2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k;

--- a/src/matrix/lis_matrix_ell.c
+++ b/src/matrix/lis_matrix_ell.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_ell"
 LIS_INT lis_matrix_set_ell(LIS_INT maxnzr, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -101,8 +99,6 @@ LIS_INT lis_matrix_set_ell(LIS_INT maxnzr, LIS_INT *index, LIS_SCALAR *value, LI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_ell"
 LIS_INT lis_matrix_setDLU_ell(LIS_INT lmaxnzr, LIS_INT umaxnzr, LIS_SCALAR *diag, LIS_INT *lindex, LIS_SCALAR *lvalue, LIS_INT *uindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT	err;
@@ -158,8 +154,6 @@ LIS_INT lis_matrix_setDLU_ell(LIS_INT lmaxnzr, LIS_INT umaxnzr, LIS_SCALAR *diag
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_ell"
 LIS_INT lis_matrix_malloc_ell(LIS_INT n, LIS_INT maxnzr, LIS_INT **index, LIS_SCALAR **value)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -185,8 +179,6 @@ LIS_INT lis_matrix_malloc_ell(LIS_INT n, LIS_INT maxnzr, LIS_INT **index, LIS_SC
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_ell"
 LIS_INT lis_matrix_elements_copy_ell(LIS_INT n, LIS_INT maxnzr, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT	i,j;
@@ -226,8 +218,6 @@ LIS_INT lis_matrix_elements_copy_ell(LIS_INT n, LIS_INT maxnzr, LIS_INT *index, 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_ell"
 LIS_INT lis_matrix_copy_ell(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -316,8 +306,6 @@ LIS_INT lis_matrix_copy_ell(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_ell"
 LIS_INT lis_matrix_split_ell(LIS_MATRIX A)
 {
 	LIS_INT i,j,n,maxnzr,my_rank,nprocs,is,ie;
@@ -494,8 +482,6 @@ LIS_INT lis_matrix_split_ell(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_ell"
 LIS_INT lis_matrix_merge_ell(LIS_MATRIX A)
 {
 	LIS_INT i,j,n;
@@ -583,8 +569,6 @@ LIS_INT lis_matrix_merge_ell(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_ell"
 LIS_INT lis_matrix_get_diagonal_ell(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -626,8 +610,6 @@ LIS_INT lis_matrix_get_diagonal_ell(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_ell"
 LIS_INT lis_matrix_shift_diagonal_ell(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j;
@@ -668,8 +650,6 @@ LIS_INT lis_matrix_shift_diagonal_ell(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_ell"
 LIS_INT lis_matrix_scale_ell(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,is,ie;
@@ -746,8 +726,6 @@ LIS_INT lis_matrix_scale_ell(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_ell"
 LIS_INT lis_matrix_scale_symm_ell(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,is,ie;
@@ -824,8 +802,6 @@ LIS_INT lis_matrix_scale_symm_ell(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_ell"
 LIS_INT lis_matrix_solve_ell(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n;
@@ -889,8 +865,6 @@ LIS_INT lis_matrix_solve_ell(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_ell"
 LIS_INT lis_matrix_solvet_ell(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n;
@@ -950,8 +924,6 @@ LIS_INT lis_matrix_solvet_ell(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2ell"
 LIS_INT lis_matrix_convert_csr2ell(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k;
@@ -1066,8 +1038,6 @@ LIS_INT lis_matrix_convert_csr2ell(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_ell2csr"
 LIS_INT lis_matrix_convert_ell2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k;

--- a/src/matrix/lis_matrix_ilu.c
+++ b/src/matrix/lis_matrix_ilu.c
@@ -47,8 +47,6 @@
 #endif
 #include "lislib.h"
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_ilu_create"
 LIS_INT lis_matrix_ilu_create(LIS_INT n, LIS_INT bs, LIS_MATRIX_ILU *A)
 {
 	LIS_INT i;
@@ -104,8 +102,6 @@ LIS_INT lis_matrix_ilu_create(LIS_INT n, LIS_INT bs, LIS_MATRIX_ILU *A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_ilu_setCR"
 LIS_INT lis_matrix_ilu_setCR(LIS_MATRIX_ILU A)
 {
 	LIS_INT n;
@@ -127,8 +123,6 @@ LIS_INT lis_matrix_ilu_setCR(LIS_MATRIX_ILU A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_ilu_setVR"
 LIS_INT lis_matrix_ilu_setVR(LIS_MATRIX_ILU A)
 {
 	LIS_INT n;
@@ -158,8 +152,6 @@ LIS_INT lis_matrix_ilu_setVR(LIS_MATRIX_ILU A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_ilu_destroy"
 LIS_INT lis_matrix_ilu_destroy(LIS_MATRIX_ILU A)
 {
 	LIS_INT i,j;
@@ -200,8 +192,6 @@ LIS_INT lis_matrix_ilu_destroy(LIS_MATRIX_ILU A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_ilu_create"
 LIS_INT lis_matrix_ilu_premalloc(LIS_INT nnzrow, LIS_MATRIX_ILU A)
 {
 	LIS_INT i,n;
@@ -247,8 +237,6 @@ LIS_INT lis_matrix_ilu_premalloc(LIS_INT nnzrow, LIS_MATRIX_ILU A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_ilu_realloc"
 LIS_INT lis_matrix_ilu_realloc(LIS_INT row, LIS_INT nnz, LIS_MATRIX_ILU A)
 {
 
@@ -272,8 +260,6 @@ LIS_INT lis_matrix_ilu_realloc(LIS_INT row, LIS_INT nnz, LIS_MATRIX_ILU A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matvect_ilu"
 LIS_INT lis_matvect_ilu(LIS_MATRIX A, LIS_MATRIX_ILU LU, LIS_VECTOR X, LIS_VECTOR Y)
 {
 	LIS_INT i,j,jj,n;
@@ -373,8 +359,6 @@ LIS_INT lis_matvect_ilu(LIS_MATRIX A, LIS_MATRIX_ILU LU, LIS_VECTOR X, LIS_VECTO
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matvec_ilu"
 LIS_INT lis_matvec_ilu(LIS_MATRIX A, LIS_MATRIX_ILU LU, LIS_VECTOR X, LIS_VECTOR Y)
 {
 	LIS_INT i,j,jj,n,np;

--- a/src/matrix/lis_matrix_jad.c
+++ b/src/matrix/lis_matrix_jad.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_jad"
 LIS_INT lis_matrix_set_jad(LIS_INT nnz, LIS_INT maxnzr, LIS_INT *perm, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -121,8 +119,6 @@ LIS_INT lis_matrix_set_jad(LIS_INT nnz, LIS_INT maxnzr, LIS_INT *perm, LIS_INT *
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_jad"
 LIS_INT lis_matrix_setDLU_jad(LIS_INT lnnz, LIS_INT unnz, LIS_INT lmaxnzr, LIS_INT umaxnzr, LIS_SCALAR *diag, LIS_INT *lperm, LIS_INT *lptr, LIS_INT *lindex, LIS_SCALAR *lvalue, LIS_INT *uperm, LIS_INT *uptr, LIS_INT *uindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT n,i,err;
@@ -210,8 +206,6 @@ LIS_INT lis_matrix_setDLU_jad(LIS_INT lnnz, LIS_INT unnz, LIS_INT lmaxnzr, LIS_I
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_jad"
 LIS_INT lis_matrix_malloc_jad(LIS_INT n, LIS_INT nnz, LIS_INT maxnzr, LIS_INT **perm, LIS_INT **ptr, LIS_INT **index, LIS_SCALAR **value)
 {
 	LIS_INT	nprocs;
@@ -260,9 +254,6 @@ LIS_INT lis_matrix_malloc_jad(LIS_INT n, LIS_INT nnz, LIS_INT maxnzr, LIS_INT **
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_jad"
 LIS_INT lis_matrix_elements_copy_jad(LIS_INT n, LIS_INT maxnzr, LIS_INT *perm, LIS_INT *ptr, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_perm, LIS_INT *o_ptr, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT i,j,is,ie;
@@ -309,8 +300,6 @@ LIS_INT lis_matrix_elements_copy_jad(LIS_INT n, LIS_INT maxnzr, LIS_INT *perm, L
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_jad"
 LIS_INT lis_matrix_copy_jad(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -407,8 +396,6 @@ LIS_INT lis_matrix_copy_jad(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_jad"
 LIS_INT lis_matrix_get_diagonal_jad(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k,l;
@@ -482,8 +469,6 @@ LIS_INT lis_matrix_get_diagonal_jad(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_jad"
 LIS_INT lis_matrix_shift_diagonal_jad(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j,k,l;
@@ -557,8 +542,6 @@ LIS_INT lis_matrix_shift_diagonal_jad(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_jad"
 LIS_INT lis_matrix_scale_jad(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k,is,ie,js,je;
@@ -650,8 +633,6 @@ LIS_INT lis_matrix_scale_jad(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_jad"
 LIS_INT lis_matrix_scale_symm_jad(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k,is,ie,js,je;
@@ -743,8 +724,6 @@ LIS_INT lis_matrix_scale_symm_jad(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_jad"
 LIS_INT lis_matrix_normf_jad(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -792,8 +771,6 @@ LIS_INT lis_matrix_normf_jad(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_jad"
 LIS_INT lis_matrix_transpose_jad(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 
@@ -807,8 +784,6 @@ LIS_INT lis_matrix_transpose_jad(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_jad"
 LIS_INT lis_matrix_split_jad(LIS_MATRIX A)
 {
 	LIS_INT i,j,k,kk,n,maxnzr;
@@ -1134,9 +1109,6 @@ LIS_INT lis_matrix_split_jad(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_jad"
 LIS_INT lis_matrix_merge_jad(LIS_MATRIX A)
 {
 	LIS_INT i,j,k,kk,ie;
@@ -1386,8 +1358,6 @@ LIS_INT lis_matrix_merge_jad(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_jad"
 LIS_INT lis_matrix_sort_jad(LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -1425,8 +1395,6 @@ LIS_INT lis_matrix_sort_jad(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_jad"
 LIS_INT lis_matrix_solve_jad(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,k,l,n;
@@ -1505,8 +1473,6 @@ LIS_INT lis_matrix_solve_jad(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_jad"
 LIS_INT lis_matrix_solvet_jad(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,k,l,n;
@@ -1583,8 +1549,6 @@ LIS_INT lis_matrix_solvet_jad(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 }
 
 #ifndef USE_OVERLAP
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2jad"
 LIS_INT lis_matrix_convert_csr2jad(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,l,js,je;
@@ -1764,8 +1728,6 @@ LIS_INT lis_matrix_convert_csr2jad(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 #else
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2jad"
 LIS_INT lis_matrix_convert_csr2jad(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,jj,k,kk,l,js,je;
@@ -2037,8 +1999,6 @@ LIS_INT lis_matrix_convert_csr2jad(LIS_MATRIX Ain, LIS_MATRIX Aout)
 }
 #endif
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_jad2csr"
 LIS_INT lis_matrix_convert_jad2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,jj,k,is,ie;
@@ -2175,9 +2135,6 @@ LIS_INT lis_matrix_convert_jad2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_vector_sort_jad_order"
 LIS_INT lis_vector_sort_jad_order(LIS_MATRIX A, LIS_VECTOR v)
 {
 	LIS_INT i,n,np;
@@ -2211,8 +2168,6 @@ LIS_INT lis_vector_sort_jad_order(LIS_MATRIX A, LIS_VECTOR v)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_vector_sort_ascending_order"
 LIS_INT lis_vector_sort_ascending_order(LIS_MATRIX A, LIS_VECTOR v)
 {
 	LIS_INT i,n,np;

--- a/src/matrix/lis_matrix_mpi.c
+++ b/src/matrix/lis_matrix_mpi.c
@@ -51,8 +51,6 @@
  * lis_matrix_g2l
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_g2l"
 LIS_INT lis_matrix_g2l(LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -217,8 +215,6 @@ LIS_INT lis_matrix_g2l_csr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 #else
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_g2l_csr"
 LIS_INT lis_matrix_g2l_csr(LIS_MATRIX A)
 {
 	LIS_INT i,j,jj,k;
@@ -320,8 +316,6 @@ LIS_INT lis_matrix_g2l_csr(LIS_MATRIX A)
 }
 #endif
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_g2l_rco"
 LIS_INT lis_matrix_g2l_rco(LIS_MATRIX A)
 {
 	LIS_INT i,j,jj,k;
@@ -418,8 +412,6 @@ LIS_INT lis_matrix_g2l_rco(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_commtable_destroy"
 void lis_commtable_destroy(LIS_COMMTABLE table)
 {
 	if( table )
@@ -447,8 +439,6 @@ void lis_commtable_destroy(LIS_COMMTABLE table)
 }
 
 #ifdef USE_MPI
-#undef __FUNC__
-#define __FUNC__ "lis_commtable_duplicate"
 LIS_INT lis_commtable_duplicate(LIS_COMMTABLE tin, LIS_COMMTABLE *tout)
 {
 	LIS_INT i;
@@ -571,8 +561,6 @@ LIS_INT lis_commtable_duplicate(LIS_COMMTABLE tin, LIS_COMMTABLE *tout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_commtable_duplicateM"
 LIS_INT lis_commtable_duplicateM(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 	LIS_INT err;
@@ -589,8 +577,6 @@ LIS_INT lis_commtable_duplicateM(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_commtable_create"
 LIS_INT lis_commtable_create(LIS_MATRIX A)
 {
 	LIS_INT i,k,excount;
@@ -829,8 +815,6 @@ LIS_INT lis_commtable_create(LIS_MATRIX A)
 #endif
 
 #ifdef USE_MPI
-#undef __FUNC__
-#define __FUNC__ "lis_send_recv"
 LIS_INT lis_send_recv(LIS_COMMTABLE commtable, LIS_SCALAR x[])
 {
 	LIS_INT neib,i,is,inum,neibpetot,k,pad;
@@ -954,8 +938,6 @@ LIS_INT lis_send_recv(LIS_COMMTABLE commtable, LIS_SCALAR x[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_reduce"
 LIS_INT lis_reduce(LIS_COMMTABLE commtable, LIS_SCALAR x[])
 {
 	LIS_INT neib,i,is,inum,neibpetot,pad;
@@ -1542,8 +1524,6 @@ LIS_INT lis_matrix_redistribute_csr(LIS_MATRIX Ain, LIS_MATRIX *Aout, LIS_INT re
 }
 #endif
 
-#undef __FUNC__
-#define __FUNC__ "lis_vector_redistribute"
 LIS_INT lis_vector_redistribute(LIS_MATRIX Ain, LIS_VECTOR vin, LIS_VECTOR *vout)
 {
 	LIS_INT i,k,count;

--- a/src/matrix/lis_matrix_msr.c
+++ b/src/matrix/lis_matrix_msr.c
@@ -73,8 +73,6 @@
  * lis_matrix_solvet           | xxx | o   |
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_msr"
 LIS_INT lis_matrix_set_msr(LIS_INT nnz, LIS_INT ndz, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -103,8 +101,6 @@ LIS_INT lis_matrix_set_msr(LIS_INT nnz, LIS_INT ndz, LIS_INT *index, LIS_SCALAR 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_setDLU_msr"
 LIS_INT lis_matrix_setDLU_msr(LIS_INT lnnz, LIS_INT unnz, LIS_INT lndz, LIS_INT undz, LIS_SCALAR *diag, LIS_INT *lindex, LIS_SCALAR *lvalue, LIS_INT *uindex, LIS_SCALAR *uvalue, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -162,8 +158,6 @@ LIS_INT lis_matrix_setDLU_msr(LIS_INT lnnz, LIS_INT unnz, LIS_INT lndz, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_msr"
 LIS_INT lis_matrix_malloc_msr(LIS_INT n, LIS_INT nnz, LIS_INT ndz, LIS_INT **index, LIS_SCALAR **value)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -189,9 +183,6 @@ LIS_INT lis_matrix_malloc_msr(LIS_INT n, LIS_INT nnz, LIS_INT ndz, LIS_INT **ind
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_msr"
 LIS_INT lis_matrix_elements_copy_msr(LIS_INT n, LIS_INT *index, LIS_SCALAR *value, LIS_INT *o_index, LIS_SCALAR *o_value)
 {
 	LIS_INT i,j;
@@ -227,8 +218,6 @@ LIS_INT lis_matrix_elements_copy_msr(LIS_INT n, LIS_INT *index, LIS_SCALAR *valu
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_msr"
 LIS_INT lis_matrix_copy_msr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -319,8 +308,6 @@ LIS_INT lis_matrix_copy_msr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_msr"
 LIS_INT lis_matrix_get_diagonal_msr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i;
@@ -353,8 +340,6 @@ LIS_INT lis_matrix_get_diagonal_msr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_msr"
 LIS_INT lis_matrix_shift_diagonal_msr(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i;
@@ -387,8 +372,6 @@ LIS_INT lis_matrix_shift_diagonal_msr(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_msr"
 LIS_INT lis_matrix_scale_msr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -433,8 +416,6 @@ LIS_INT lis_matrix_scale_msr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_msr"
 LIS_INT lis_matrix_scale_symm_msr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j;
@@ -479,8 +460,6 @@ LIS_INT lis_matrix_scale_symm_msr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_normf_msr"
 LIS_INT lis_matrix_normf_msr(LIS_MATRIX A, LIS_SCALAR *nrm)
 {
 	LIS_INT i,j;
@@ -528,8 +507,6 @@ LIS_INT lis_matrix_normf_msr(LIS_MATRIX A, LIS_SCALAR *nrm)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_transpose_msr"
 LIS_INT lis_matrix_transpose_msr(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 {
 
@@ -543,8 +520,6 @@ LIS_INT lis_matrix_transpose_msr(LIS_MATRIX Ain, LIS_MATRIX *Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_msr"
 LIS_INT lis_matrix_split_msr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n;
@@ -728,9 +703,6 @@ LIS_INT lis_matrix_split_msr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_msr"
 LIS_INT lis_matrix_merge_msr(LIS_MATRIX A)
 {
 	LIS_INT i,j,n,is;
@@ -808,8 +780,6 @@ LIS_INT lis_matrix_merge_msr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_sort_msr"
 LIS_INT lis_matrix_sort_msr(LIS_MATRIX A)
 {
 	LIS_INT i,n;
@@ -846,9 +816,7 @@ LIS_INT lis_matrix_sort_msr(LIS_MATRIX A)
 	LIS_DEBUG_FUNC_OUT;
 	return LIS_SUCCESS;
 }
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_msr"
+h
 LIS_INT lis_matrix_solve_msr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n;
@@ -913,8 +881,6 @@ LIS_INT lis_matrix_solve_msr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_msr"
 LIS_INT lis_matrix_solvet_msr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,n;
@@ -974,8 +940,6 @@ LIS_INT lis_matrix_solvet_msr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2msr"
 LIS_INT lis_matrix_convert_csr2msr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,jj;
@@ -1107,8 +1071,6 @@ LIS_INT lis_matrix_convert_csr2msr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_msr2csr"
 LIS_INT lis_matrix_convert_msr2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k;

--- a/src/matrix/lis_matrix_ops.c
+++ b/src/matrix/lis_matrix_ops.c
@@ -65,8 +65,6 @@
  * lis_matrix_solvet
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_blocksize"
 LIS_INT lis_matrix_set_blocksize(LIS_MATRIX A, LIS_INT bnr, LIS_INT bnc, LIS_INT row[], LIS_INT col[])
 {
 	LIS_INT i,n;
@@ -122,8 +120,6 @@ LIS_INT lis_matrix_set_blocksize(LIS_MATRIX A, LIS_INT bnr, LIS_INT bnc, LIS_INT
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert"
 LIS_INT lis_matrix_convert(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -320,8 +316,6 @@ LIS_INT lis_matrix_convert(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return err;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_self"
 LIS_INT lis_matrix_convert_self(LIS_SOLVER solver)
 {
 	LIS_INT err;
@@ -366,8 +360,6 @@ LIS_INT lis_matrix_convert_self(LIS_SOLVER solver)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy"
 LIS_INT lis_matrix_copy(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -423,8 +415,6 @@ LIS_INT lis_matrix_copy(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copyDLU"
 LIS_INT lis_matrix_copyDLU(LIS_MATRIX Ain, LIS_MATRIX_DIAG *D, LIS_MATRIX *L, LIS_MATRIX *U)
 {
 	LIS_INT err;
@@ -483,8 +473,6 @@ LIS_INT lis_matrix_copyDLU(LIS_MATRIX Ain, LIS_MATRIX_DIAG *D, LIS_MATRIX *L, LI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_axpy"
 LIS_INT lis_matrix_axpy(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 {
 	LIS_INT err;
@@ -512,8 +500,6 @@ LIS_INT lis_matrix_axpy(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_xpay"
 LIS_INT lis_matrix_xpay(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 {
 	LIS_INT err;
@@ -541,8 +527,6 @@ LIS_INT lis_matrix_xpay(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_axpyz"
 LIS_INT lis_matrix_axpyz(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B, LIS_MATRIX C)
 {
 	LIS_INT err;
@@ -573,8 +557,6 @@ LIS_INT lis_matrix_axpyz(LIS_SCALAR alpha, LIS_MATRIX A, LIS_MATRIX B, LIS_MATRI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale"
 LIS_INT lis_matrix_scale(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR D, LIS_INT action)
 {
 	LIS_INT i,n,np;
@@ -712,9 +694,7 @@ LIS_INT lis_matrix_scale(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR D, LIS_INT actio
 	B->is_scaled = LIS_TRUE;
 	return LIS_SUCCESS;
 }
- 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal"
+
 LIS_INT lis_matrix_get_diagonal(LIS_MATRIX A, LIS_VECTOR D)
 {
 	LIS_SCALAR *d;
@@ -766,8 +746,6 @@ LIS_INT lis_matrix_get_diagonal(LIS_MATRIX A, LIS_VECTOR D)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal"
 LIS_INT lis_matrix_shift_diagonal(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 
@@ -818,8 +796,6 @@ LIS_INT lis_matrix_shift_diagonal(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split"
 LIS_INT lis_matrix_split(LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -885,8 +861,6 @@ LIS_INT lis_matrix_split(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge"
 LIS_INT lis_matrix_merge(LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -951,8 +925,6 @@ LIS_INT lis_matrix_merge(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve"
 LIS_INT lis_matrix_solve(LIS_MATRIX A, LIS_VECTOR b, LIS_VECTOR x, LIS_INT flag)
 {
 	LIS_DEBUG_FUNC_IN;
@@ -1001,8 +973,6 @@ LIS_INT lis_matrix_solve(LIS_MATRIX A, LIS_VECTOR b, LIS_VECTOR x, LIS_INT flag)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet"
 LIS_INT lis_matrix_solvet(LIS_MATRIX A, LIS_VECTOR b, LIS_VECTOR x, LIS_INT flag)
 {
 	LIS_DEBUG_FUNC_IN;

--- a/src/matrix/lis_matrix_rco.c
+++ b/src/matrix/lis_matrix_rco.c
@@ -53,8 +53,6 @@
  * lis_matrix_realloc
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_create_rco"
 LIS_INT lis_matrix_create_rco(LIS_INT local_n, LIS_INT global_n, LIS_Comm comm, LIS_INT annz, LIS_INT *nnz, LIS_MATRIX *Amat)
 {
 	LIS_INT nprocs,my_rank;
@@ -141,8 +139,6 @@ LIS_INT lis_matrix_create_rco(LIS_INT local_n, LIS_INT global_n, LIS_Comm comm, 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_rco"
 LIS_INT lis_matrix_malloc_rco(LIS_INT n, LIS_INT nnz[], LIS_INT **row, LIS_INT ***index, LIS_SCALAR ***value)
 {
 	LIS_INT	i,j;
@@ -218,8 +214,6 @@ LIS_INT lis_matrix_malloc_rco(LIS_INT n, LIS_INT nnz[], LIS_INT **row, LIS_INT *
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_realloc_rco"
 LIS_INT lis_matrix_realloc_rco(LIS_INT row, LIS_INT nnz, LIS_INT ***index, LIS_SCALAR ***value)
 {
 	LIS_INT **w_index;
@@ -249,8 +243,6 @@ LIS_INT lis_matrix_realloc_rco(LIS_INT row, LIS_INT nnz, LIS_INT ***index, LIS_S
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_rco2csr"
 LIS_INT lis_matrix_convert_rco2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,n,nnz,err;
@@ -320,8 +312,6 @@ LIS_INT lis_matrix_convert_rco2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_rco2bsr"
 LIS_INT lis_matrix_convert_rco2bsr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,n,gn,nnz,bnnz,nr,nc,bnr,bnc,err;
@@ -484,8 +474,6 @@ LIS_INT lis_matrix_convert_rco2bsr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_rco2csc"
 LIS_INT lis_matrix_convert_rco2csc(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,l,n,nnz,err;

--- a/src/matrix/lis_matrix_vbr.c
+++ b/src/matrix/lis_matrix_vbr.c
@@ -61,8 +61,6 @@
  * lis_matrix_transpose
  ************************************************/
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_set_vbr"
 LIS_INT lis_matrix_set_vbr(LIS_INT nnz, LIS_INT nr, LIS_INT nc, LIS_INT bnnz, LIS_INT *row, LIS_INT *col, LIS_INT *ptr, LIS_INT *bptr, LIS_INT *bindex, LIS_SCALAR *value, LIS_MATRIX A)
 {
 	LIS_INT err;
@@ -98,8 +96,6 @@ LIS_INT lis_matrix_set_vbr(LIS_INT nnz, LIS_INT nr, LIS_INT nc, LIS_INT bnnz, LI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_malloc_vbr"
 LIS_INT lis_matrix_malloc_vbr(LIS_INT n, LIS_INT nnz, LIS_INT nr, LIS_INT nc, LIS_INT bnnz, LIS_INT **row, LIS_INT **col, LIS_INT **ptr, LIS_INT **bptr, LIS_INT **bindex, LIS_SCALAR **value)
 {
 
@@ -158,8 +154,6 @@ LIS_INT lis_matrix_malloc_vbr(LIS_INT n, LIS_INT nnz, LIS_INT nr, LIS_INT nc, LI
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_elements_copy_vbr"
 LIS_INT lis_matrix_elements_copy_vbr(LIS_INT n, LIS_INT nr, LIS_INT nc, LIS_INT bnnz, LIS_INT *row, LIS_INT *col, LIS_INT *ptr, LIS_INT *bptr, LIS_INT *bindex, LIS_SCALAR *value, LIS_INT *o_row, LIS_INT *o_col, LIS_INT *o_ptr, LIS_INT *o_bptr, LIS_INT *o_bindex, LIS_SCALAR *o_value)
 {
 	LIS_INT bi,bj,i,j,k;
@@ -213,8 +207,6 @@ LIS_INT lis_matrix_elements_copy_vbr(LIS_INT n, LIS_INT nr, LIS_INT nc, LIS_INT 
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_copy_vbr"
 LIS_INT lis_matrix_copy_vbr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT err;
@@ -254,8 +246,6 @@ LIS_INT lis_matrix_copy_vbr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_vbr_rowcol"
 LIS_INT lis_matrix_get_vbr_rowcol(LIS_MATRIX Ain, LIS_INT *nr, LIS_INT *nc, LIS_INT **row, LIS_INT **col)
 {
 	LIS_INT i,j,k,jj,kk,n;
@@ -493,8 +483,6 @@ LIS_INT lis_matrix_get_vbr_rowcol(LIS_MATRIX Ain, LIS_INT *nr, LIS_INT *nc, LIS_
 }
 #endif
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_csr2vbr"
 LIS_INT lis_matrix_convert_csr2vbr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,n;
@@ -738,8 +726,6 @@ LIS_INT lis_matrix_convert_csr2vbr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_convert_vbr2csr"
 LIS_INT lis_matrix_convert_vbr2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 {
 	LIS_INT i,j,k,l;
@@ -868,8 +854,6 @@ LIS_INT lis_matrix_convert_vbr2csr(LIS_MATRIX Ain, LIS_MATRIX Aout)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_get_diagonal_vbr"
 LIS_INT lis_matrix_get_diagonal_vbr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k,bi,bj,bjj,nr;
@@ -929,8 +913,6 @@ LIS_INT lis_matrix_get_diagonal_vbr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_shift_diagonal_vbr"
 LIS_INT lis_matrix_shift_diagonal_vbr(LIS_MATRIX A, LIS_SCALAR alpha)
 {
 	LIS_INT i,j,k,bi,bj,bjj,nr;
@@ -990,8 +972,6 @@ LIS_INT lis_matrix_shift_diagonal_vbr(LIS_MATRIX A, LIS_SCALAR alpha)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_vbr"
 LIS_INT lis_matrix_scale_vbr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k;
@@ -1069,8 +1049,6 @@ LIS_INT lis_matrix_scale_vbr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_scale_symm_vbr"
 LIS_INT lis_matrix_scale_symm_vbr(LIS_MATRIX A, LIS_SCALAR d[])
 {
 	LIS_INT i,j,k;
@@ -1111,9 +1089,6 @@ LIS_INT lis_matrix_scale_symm_vbr(LIS_MATRIX A, LIS_SCALAR d[])
 	return LIS_SUCCESS;
 }
 
-
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_split_vbr"
 LIS_INT lis_matrix_split_vbr(LIS_MATRIX A)
 {
 	LIS_INT i,j,jj,n;
@@ -1400,8 +1375,6 @@ LIS_INT lis_matrix_split_vbr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_merge_vbr"
 LIS_INT lis_matrix_merge_vbr(LIS_MATRIX A)
 {
 	LIS_INT i,j,jj,n,nnz;
@@ -1486,8 +1459,6 @@ LIS_INT lis_matrix_merge_vbr(LIS_MATRIX A)
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solve_vbr"
 LIS_INT lis_matrix_solve_vbr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,jj,nr,bnr,dim,sz;
@@ -1568,8 +1539,6 @@ LIS_INT lis_matrix_solve_vbr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT f
 	return LIS_SUCCESS;
 }
 
-#undef __FUNC__
-#define __FUNC__ "lis_matrix_solvet_vbr"
 LIS_INT lis_matrix_solvet_vbr(LIS_MATRIX A, LIS_VECTOR B, LIS_VECTOR X, LIS_INT flag)
 {
 	LIS_INT i,j,jj,nr,bnr,dim,sz;


### PR DESCRIPTION
**FUNC** is a  Standard Predefined Macro [1] so it is not needed

[1] https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html

Signed-off-by: Lehner Florian dev@der-flo.net
