### PR TITLE
add lis_matrix_unset() to lis.h

### DIFF
--- a/include/lis.h
+++ b/include/lis.h
@@ -737,6 +737,7 @@ extern "C"
 	extern LIS_INT lis_matrix_convert(LIS_MATRIX Ain, LIS_MATRIX Aout);
 	extern LIS_INT lis_matrix_copy(LIS_MATRIX Ain, LIS_MATRIX Aout);
 	extern LIS_INT lis_matrix_set_blocksize(LIS_MATRIX A, LIS_INT bnr, LIS_INT bnc, LIS_INT row[], LIS_INT col[]);
+	extern LIS_INT lis_matrix_unset(LIS_MATRIX A);
 
 	extern LIS_INT lis_matrix_malloc_csr(LIS_INT n, LIS_INT nnz, LIS_INT **ptr, LIS_INT **index, LIS_SCALAR **value);
 	extern LIS_INT lis_matrix_set_csr(LIS_INT nnz, LIS_INT *row, LIS_INT *index, LIS_SCALAR *value, LIS_MATRIX A);


### PR DESCRIPTION
Hi, I've found that `lis_matrix_unset()` is not available from c/c++ code. Simply adding the declaration in lis.h solved the problem (I'm unsure if that's a correct way to fix the problem). 
