### PR TITLE
Add MPI management functionality

### DIFF
--- a/include/lis.h
+++ b/include/lis.h
@@ -1029,6 +1029,7 @@ extern "C"
 /* Utilities                */
 /****************************/
 
+	extern void lis_do_not_handle_mpi();
 	extern LIS_INT lis_initialize(int *argc, char** argv[]);
 	extern LIS_INT lis_finalize(void);
 	extern double lis_wtime(void);

--- a/include/lis_system.h
+++ b/include/lis_system.h
@@ -66,6 +66,7 @@ extern "C"
 	extern LIS_ARGS cmd_args;
 	extern LIS_SCALAR *lis_vec_tmp;
 	extern int lis_mpi_initialized;
+	extern int lis_mpi_management;
 #ifdef USE_MPI
 	extern MPI_Op LIS_MPI_MSUM;
 	extern MPI_Datatype LIS_MPI_MSCALAR;

--- a/src/system/lis_error.c
+++ b/src/system/lis_error.c
@@ -71,8 +71,11 @@ LIS_INT lis_debug_trace_func(LIS_INT flag, char *func)
 	int argc=0;
 
 	#ifdef USE_MPI
+	if (lis_mpi_management)
+	{
 		MPI_Initialized(&lis_mpi_initialized);
 		if (!lis_mpi_initialized) MPI_Init(&argc, NULL);
+	}
 	#endif
 	if( flag )
 	{
@@ -87,9 +90,10 @@ LIS_INT lis_debug_trace_func(LIS_INT flag, char *func)
 		lis_printf(lis_debug_comm, buf, "OUT", func);
 	}
 	#ifdef USE_MPI
-		if( strcmp(func,"main")==0 && !flag )
+		if (strcmp(func, "main") == 0 && !flag && lis_mpi_management)
 		{
-			MPI_Finalize();
+			MPI_Finalized(&lis_mpi_initialized); // reuse lis_mpi_initialized
+			if (!lis_mpi_initialized) MPI_Finalize();
 		}
 	#endif
 	return LIS_SUCCESS;

--- a/src/system/lis_init.c
+++ b/src/system/lis_init.c
@@ -62,6 +62,7 @@
 
 LIS_ARGS cmd_args = NULL;
 int lis_mpi_initialized = LIS_FALSE;
+int lis_mpi_management = LIS_TRUE;
 LIS_SCALAR *lis_vec_tmp = NULL;
 
 #ifdef USE_QUAD_PRECISION
@@ -94,6 +95,17 @@ LIS_INT LIS_INIT_OPTACT[] = {
  ************************************************/
 
 #undef __FUNC__
+#define __FUNC__ "lis_do_not_handle_mpi"
+void lis_do_not_handle_mpi(void)
+{
+	LIS_DEBUG_FUNC_IN;
+
+	lis_mpi_management = LIS_FALSE;
+
+	LIS_DEBUG_FUNC_OUT;
+}
+
+#undef __FUNC__
 #define __FUNC__ "lis_version"
 void lis_version(void)
 {
@@ -116,8 +128,11 @@ LIS_INT lis_initialize(int* argc, char** argv[])
 /*	lis_memory_init();*/
 
 	#ifdef USE_MPI
-		MPI_Initialized(&lis_mpi_initialized);
-		if (!lis_mpi_initialized) MPI_Init(argc, argv);
+		if (lis_mpi_management)
+		{
+			MPI_Initialized(&lis_mpi_initialized);
+			if (!lis_mpi_initialized) MPI_Init(argc, argv);
+		}
 
 		#ifdef USE_QUAD_PRECISION
 			MPI_Type_contiguous(LIS_MPI_MSCALAR_LEN, MPI_DOUBLE, &LIS_MPI_MSCALAR );
@@ -217,7 +232,11 @@ LIS_INT lis_finalize(void)
 	lis_free_all();
 	
 	#ifdef USE_MPI
+	if (lis_mpi_management)
+	{
+		MPI_Finalized(&lis_mpi_initialized); // reuse lis_mpi_initialized
 		if (!lis_mpi_initialized) MPI_Finalize();
+	}
 	#endif
 
 	LIS_DEBUG_FUNC_OUT;


### PR DESCRIPTION
Currently `lis` manages the MPI environment and there is no way to disable it.
`MPI_Init` is conditionally called but `MPI_Finalize` is not, there is a risk of calling it multiple times, when `lis` is used with other MPI applications/libraries.

It would be helpful if there is a mechanism to control whether to let `lis` manage the MPI environment.
In some more complex setup, this may be handled separately by other libraries.

This PR introduces a new function `lis_do_not_handle_mpi()`.
It can be called before `lis_initialize` so that `lis` does not touch MPI.

Also, `MPI_Finalized` is added to ensure `MPI_Finalize` is called only once.