### PR TITLE
Update eigenvalue condition in lis_eai function

### DIFF
--- a/src/esolver/lis_esolver_ai.c
+++ b/src/esolver/lis_esolver_ai.c
@@ -255,7 +255,7 @@ LIS_INT lis_eai(LIS_ESOLVER esolver)
       i = i + 1;
 
       /* eigenvalues on the diagonal of H */
-      if (fabs(h[i+(i-1)*ss])<tol)
+      if (ss==i||fabs(h[i+(i-1)*ss])<tol)
 	{
 	  if( output ) 
 	    {


### PR DESCRIPTION
Enhance the eigenvalue condition check in the lis_eai function to include a comparison of ss and i.