### PR TITLE
Fix memory leak in loop

### DIFF
--- a/src/esolver/lis_esolver_ai.c
+++ b/src/esolver/lis_esolver_ai.c
@@ -324,17 +324,17 @@ LIS_INT lis_eai(LIS_ESOLVER esolver)
       lis_printf(comm,"computing refined eigenpairs using inner eigensolver:\n\n");
     }
 
-  lis_esolver_create(&esolver2);
-  esolver2->options[LIS_EOPTIONS_ESOLVER] = niesolver;
-  esolver2->options[LIS_EOPTIONS_SUBSPACE] = 1;
-  esolver2->options[LIS_EOPTIONS_MAXITER] = emaxiter;
-  esolver2->options[LIS_EOPTIONS_OUTPUT] = esolver->options[LIS_EOPTIONS_OUTPUT];
-  esolver2->params[LIS_EPARAMS_RESID - LIS_EOPTIONS_LEN] = tol;
-
   /* compute refined (real) eigenpairs */
 
   for (i=0;i<ss;i++)
     {
+      lis_esolver_create(&esolver2);
+      esolver2->options[LIS_EOPTIONS_ESOLVER] = niesolver;
+      esolver2->options[LIS_EOPTIONS_SUBSPACE] = 1;
+      esolver2->options[LIS_EOPTIONS_MAXITER] = emaxiter;
+      esolver2->options[LIS_EOPTIONS_OUTPUT] = esolver->options[LIS_EOPTIONS_OUTPUT];
+      esolver2->params[LIS_EPARAMS_RESID - LIS_EOPTIONS_LEN] = tol;
+
       lis_vector_duplicate(A, &esolver->evector[i]); 
       esolver2->ishift = esolver->evalue[i];
       lis_esolve(A, esolver->evector[i], &evalue, esolver2);
@@ -374,11 +374,11 @@ LIS_INT lis_eai(LIS_ESOLVER esolver)
 	  lis_printf(comm,"Arnoldi: number of iterations = %D\n",esolver2->iter[0]);
 	  lis_printf(comm,"Arnoldi: relative residual    = %e\n\n",(double)esolver2->resid[0]);
 	}
+
+      lis_esolver_destroy(esolver2); 
     }
 
   lis_vector_copy(esolver->evector[0], esolver->x);
-
-  lis_esolver_destroy(esolver2); 
 
   lis_free(h); 
   lis_free(hq);


### PR DESCRIPTION
Create and destroy the inner eigensolver within the loop for each refined eigenpair to improve resource management and efficiency.